### PR TITLE
Add simple tennis cognitive training drill

### DIFF
--- a/drill.js
+++ b/drill.js
@@ -1,0 +1,95 @@
+const canvas = document.getElementById('court');
+const ctx = canvas.getContext('2d');
+const startBtn = document.getElementById('start');
+const summary = document.getElementById('summary');
+
+const TARGET_RADIUS = 12;
+const NUM_TRIALS = 5;
+
+let target = null; // {x, y}
+let trial = 0;
+let reactionTimes = [];
+let startTime = 0;
+let timerId = null;
+
+function drawCourt() {
+  ctx.fillStyle = '#317a2e';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.strokeStyle = '#fff';
+  ctx.lineWidth = 2;
+  // outer lines
+  ctx.strokeRect(10, 10, canvas.width - 20, canvas.height - 20);
+  // center line
+  ctx.beginPath();
+  ctx.moveTo(canvas.width / 2, 10);
+  ctx.lineTo(canvas.width / 2, canvas.height - 10);
+  ctx.stroke();
+  // service line
+  ctx.beginPath();
+  ctx.moveTo(10, canvas.height / 2);
+  ctx.lineTo(canvas.width - 10, canvas.height / 2);
+  ctx.stroke();
+}
+
+function spawnTarget() {
+  const x = 20 + Math.random() * (canvas.width - 40);
+  const y = 20 + Math.random() * (canvas.height - 40);
+  target = { x, y };
+  drawCourt();
+  ctx.fillStyle = '#ff0';
+  ctx.beginPath();
+  ctx.arc(x, y, TARGET_RADIUS, 0, Math.PI * 2);
+  ctx.fill();
+  startTime = performance.now();
+}
+
+function clearTarget() {
+  target = null;
+  drawCourt();
+}
+
+canvas.addEventListener('click', (e) => {
+  if (!target) return;
+  const rect = canvas.getBoundingClientRect();
+  const x = e.clientX - rect.left;
+  const y = e.clientY - rect.top;
+  const dx = x - target.x;
+  const dy = y - target.y;
+  if (Math.sqrt(dx * dx + dy * dy) <= TARGET_RADIUS) {
+    const rt = performance.now() - startTime;
+    reactionTimes.push(rt);
+    trial++;
+    clearTarget();
+    nextTrial();
+  }
+});
+
+function nextTrial() {
+  if (trial >= NUM_TRIALS) {
+    endSession();
+    return;
+  }
+  const delay = 1000 + Math.random() * 2000;
+  timerId = setTimeout(spawnTarget, delay);
+}
+
+function startSession() {
+  trial = 0;
+  reactionTimes = [];
+  summary.textContent = '';
+  clearTarget();
+  nextTrial();
+}
+
+function endSession() {
+  clearTimeout(timerId);
+  clearTarget();
+  if (!reactionTimes.length) return;
+  const sum = reactionTimes.reduce((a, b) => a + b, 0);
+  const avg = sum / reactionTimes.length;
+  summary.textContent = `Temps de réaction moyen: ${avg.toFixed(0)} ms`;
+}
+
+startBtn.addEventListener('click', startSession);
+
+drawCourt();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<title>Entraînement Cognitif et Visuel - Tennis</title>
+<style>
+  body { display:flex; flex-direction:column; align-items:center; font-family:Arial, sans-serif; }
+  #court { border:1px solid #000; background:#317a2e; margin-top:20px; }
+  #start { margin-top:15px; padding:10px 20px; }
+  #summary { margin-top:15px; font-weight:bold; }
+</style>
+</head>
+<body>
+<canvas id="court" width="600" height="300"></canvas>
+<button id="start">Démarrer la session</button>
+<div id="summary"></div>
+<script src="drill.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add minimal HTML interface with canvas for tennis training
- implement drill logic to spawn random targets and track reaction time

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a383bbc5088321ab2d88b8d4b73502