### PR TITLE
Improve tennis drill visuals and stats

### DIFF
--- a/drill.js
+++ b/drill.js
@@ -2,6 +2,8 @@ const canvas = document.getElementById('court');
 const ctx = canvas.getContext('2d');
 const startBtn = document.getElementById('start');
 const summary = document.getElementById('summary');
+const stats = document.getElementById('stats');
+const progressBar = document.getElementById('progressBar');
 
 const TARGET_RADIUS = 12;
 const NUM_TRIALS = 5;
@@ -11,6 +13,7 @@ let trial = 0;
 let reactionTimes = [];
 let startTime = 0;
 let timerId = null;
+let bestAvg = Number(localStorage.getItem('bestAvg')) || null;
 
 function drawCourt() {
   ctx.fillStyle = '#317a2e';
@@ -59,6 +62,7 @@ canvas.addEventListener('click', (e) => {
     const rt = performance.now() - startTime;
     reactionTimes.push(rt);
     trial++;
+    updateStats();
     clearTarget();
     nextTrial();
   }
@@ -77,6 +81,8 @@ function startSession() {
   trial = 0;
   reactionTimes = [];
   summary.textContent = '';
+  stats.innerHTML = '';
+  progressBar.style.width = '0%';
   clearTarget();
   nextTrial();
 }
@@ -87,9 +93,25 @@ function endSession() {
   if (!reactionTimes.length) return;
   const sum = reactionTimes.reduce((a, b) => a + b, 0);
   const avg = sum / reactionTimes.length;
-  summary.textContent = `Temps de réaction moyen: ${avg.toFixed(0)} ms`;
+  const best = Math.min(...reactionTimes);
+  const worst = Math.max(...reactionTimes);
+  if (bestAvg === null || avg < bestAvg) {
+    bestAvg = avg;
+    localStorage.setItem('bestAvg', bestAvg);
+  }
+  summary.innerHTML =
+    `Temps moyen: ${avg.toFixed(0)} ms<br>` +
+    `Meilleur: ${best.toFixed(0)} ms - Pire: ${worst.toFixed(0)} ms<br>` +
+    `Record: ${bestAvg.toFixed(0)} ms`;
 }
 
 startBtn.addEventListener('click', startSession);
+
+function updateStats() {
+  stats.innerHTML = reactionTimes
+    .map((rt, i) => `Essai ${i + 1}: ${rt.toFixed(0)} ms`)
+    .join('<br>');
+  progressBar.style.width = `${(trial / NUM_TRIALS) * 100}%`;
+}
 
 drawCourt();

--- a/index.html
+++ b/index.html
@@ -4,15 +4,33 @@
 <meta charset="UTF-8">
 <title>Entraînement Cognitif et Visuel - Tennis</title>
 <style>
-  body { display:flex; flex-direction:column; align-items:center; font-family:Arial, sans-serif; }
-  #court { border:1px solid #000; background:#317a2e; margin-top:20px; }
+  body {
+    display:flex;
+    flex-direction:column;
+    align-items:center;
+    font-family:Arial, sans-serif;
+    background:linear-gradient(#9be15d,#00e3ae);
+    min-height:100vh;
+  }
+  #court {
+    border:1px solid #000;
+    background:#317a2e;
+    margin-top:20px;
+    box-shadow:0 4px 8px rgba(0,0,0,0.3);
+    border-radius:4px;
+  }
   #start { margin-top:15px; padding:10px 20px; }
-  #summary { margin-top:15px; font-weight:bold; }
+  #summary { margin-top:15px; font-weight:bold; text-align:center; }
+  #stats { margin-top:15px; }
+  #progress { width:600px; height:10px; background:#ccc; border-radius:5px; overflow:hidden; margin-top:10px; }
+  #progressBar { width:0; height:100%; background:#4caf50; }
 </style>
 </head>
 <body>
 <canvas id="court" width="600" height="300"></canvas>
 <button id="start">Démarrer la session</button>
+<div id="progress"><div id="progressBar"></div></div>
+<div id="stats"></div>
 <div id="summary"></div>
 <script src="drill.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- Style the training page with a gradient background, progress bar, and stats area
- Track per-trial reaction times and display best, worst, and average with persistent record

## Testing
- `node --check drill.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3885fcd9c8321b79c69502fa58d27