### PR TITLE
feat: add user schedule and admin planning

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <title>Administration - Planning</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="site-header">
+    <h1>Administration</h1>
+    <nav><a href="index.html">Accueil</a></nav>
+  </header>
+  <section>
+    <h2>Planning</h2>
+    <label>Date
+      <input type="date" id="adminDate" />
+    </label>
+    <div id="adminSchedule" class="schedule admin-schedule"></div>
+  </section>
+  <script src="admin.js"></script>
+</body>
+</html>

--- a/admin.js
+++ b/admin.js
@@ -1,0 +1,86 @@
+const STORAGE_KEY = 'acacias-bookings';
+const adminDate = document.getElementById('adminDate');
+const adminSchedule = document.getElementById('adminSchedule');
+
+let bookings = load();
+const STEP = 30;
+const START_DAY = 8 * 60;
+const END_DAY = 22 * 60;
+
+function load() {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+  } catch {
+    return [];
+  }
+}
+
+function save() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(bookings));
+}
+
+function timeToMinutes(t) {
+  const [h, m] = t.split(':').map(Number);
+  return h * 60 + m;
+}
+
+function minutesToTime(m) {
+  const h = Math.floor(m / 60).toString().padStart(2, '0');
+  const min = (m % 60).toString().padStart(2, '0');
+  return `${h}:${min}`;
+}
+
+function isAvailable(date, time, duration, sport, ignore) {
+  const start = timeToMinutes(time);
+  const end = start + duration;
+  return bookings.every((b, i) => {
+    if (i === ignore || b.date !== date || b.sport !== sport) return true;
+    const bStart = timeToMinutes(b.time);
+    const bEnd = bStart + parseInt(b.duration);
+    return end <= bStart || start >= bEnd;
+  });
+}
+
+function render() {
+  const date = adminDate.value;
+  adminSchedule.innerHTML = '';
+  if (!date) return;
+  for (let minutes = START_DAY; minutes <= END_DAY - 30; minutes += STEP) {
+    const time = minutesToTime(minutes);
+    const slot = document.createElement('div');
+    slot.className = 'slot';
+    slot.dataset.time = time;
+    slot.textContent = time;
+    slot.addEventListener('dragover', e => e.preventDefault());
+    slot.addEventListener('drop', e => {
+      const index = e.dataTransfer.getData('index');
+      const booking = bookings[index];
+      const duration = parseInt(booking.duration, 10);
+      if (isAvailable(date, time, duration, booking.sport, index) && minutes <= END_DAY - duration) {
+        booking.date = date;
+        booking.time = time;
+        save();
+        render();
+      }
+    });
+    adminSchedule.appendChild(slot);
+  }
+  bookings.forEach((b, i) => {
+    if (b.date !== date) return;
+    const slot = adminSchedule.querySelector(`.slot[data-time='${b.time}']`);
+    if (!slot) return;
+    slot.classList.add('booked');
+    const div = document.createElement('div');
+    div.className = 'booking';
+    div.draggable = true;
+    div.textContent = `${b.sport} • ${b.name} (${b.duration}m)`;
+    div.addEventListener('dragstart', e => {
+      e.dataTransfer.setData('index', i);
+    });
+    slot.appendChild(div);
+  });
+}
+
+adminDate.value = new Date().toISOString().split('T')[0];
+adminDate.addEventListener('change', render);
+render();

--- a/app.js
+++ b/app.js
@@ -1,37 +1,121 @@
-const form=document.getElementById('bookingForm');
-const list=document.getElementById('list');
-const STORAGE_KEY='acacias-bookings';
-let bookings=load();
-form.addEventListener('submit',e=>{
-  e.preventDefault();
-  const booking={
-    sport:form.sport.value,
-    date:form.date.value,
-    time:form.time.value,
-    duration:form.duration.value,
-    name:form.name.value
-  };
-  bookings.push(booking);
-  save();
-  form.reset();
-  render();
-});
-function render(){
-  list.innerHTML='';
-  bookings.forEach((b,i)=>{
-    const li=document.createElement('li');
-    li.textContent=`${b.date} ${b.time} - ${b.sport} (${b.duration} min) • ${b.name}`;
-    const btn=document.createElement('button');
-    btn.textContent='Supprimer';
-    btn.onclick=()=>{bookings.splice(i,1);save();render();};
+const STORAGE_KEY = 'acacias-bookings';
+const form = document.getElementById('bookingForm');
+const list = document.getElementById('list');
+const scheduleEl = document.getElementById('schedule');
+
+let bookings = load();
+const STEP = 30; // minutes
+const START_DAY = 8 * 60; // 08:00
+const END_DAY = 22 * 60; // 22:00
+
+function load() {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+  } catch {
+    return [];
+  }
+}
+
+function save() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(bookings));
+}
+
+function timeToMinutes(t) {
+  const [h, m] = t.split(':').map(Number);
+  return h * 60 + m;
+}
+
+function minutesToTime(m) {
+  const h = Math.floor(m / 60).toString().padStart(2, '0');
+  const min = (m % 60).toString().padStart(2, '0');
+  return `${h}:${min}`;
+}
+
+function isAvailable(date, time, duration, sport, ignore = -1) {
+  const start = timeToMinutes(time);
+  const end = start + duration;
+  return bookings.every((b, i) => {
+    if (i === ignore || b.date !== date || b.sport !== sport) return true;
+    const bStart = timeToMinutes(b.time);
+    const bEnd = bStart + parseInt(b.duration);
+    return end <= bStart || start >= bEnd;
+  });
+}
+
+function renderList() {
+  list.innerHTML = '';
+  bookings.forEach((b, i) => {
+    const li = document.createElement('li');
+    li.textContent = `${b.date} ${b.time} - ${b.sport} (${b.duration} min) • ${b.name}`;
+    const btn = document.createElement('button');
+    btn.textContent = 'Supprimer';
+    btn.onclick = () => {
+      bookings.splice(i, 1);
+      save();
+      renderAll();
+    };
     li.appendChild(btn);
     list.appendChild(li);
   });
 }
-function load(){
-  try{return JSON.parse(localStorage.getItem(STORAGE_KEY))||[];}catch{ return []; }
+
+function renderSchedule() {
+  const date = form.date.value;
+  const sport = form.sport.value;
+  const duration = parseInt(form.duration.value, 10);
+  scheduleEl.innerHTML = '';
+  if (!date) return;
+  for (let minutes = START_DAY; minutes <= END_DAY - duration; minutes += STEP) {
+    const time = minutesToTime(minutes);
+    const slot = document.createElement('button');
+    slot.className = 'slot';
+    slot.textContent = time;
+    if (!isAvailable(date, time, duration, sport)) {
+      slot.disabled = true;
+      slot.classList.add('booked');
+      slot.textContent = `${time}\nindisponible`;
+    } else {
+      slot.addEventListener('click', () => {
+        form.time.value = time;
+        document.querySelectorAll('#schedule .slot').forEach(s => s.classList.remove('selected'));
+        slot.classList.add('selected');
+      });
+    }
+    scheduleEl.appendChild(slot);
+  }
 }
-function save(){
-  localStorage.setItem(STORAGE_KEY,JSON.stringify(bookings));
+
+function renderAll() {
+  renderList();
+  renderSchedule();
 }
-render();
+
+form.addEventListener('submit', e => {
+  e.preventDefault();
+  const booking = {
+    sport: form.sport.value,
+    date: form.date.value,
+    time: form.time.value,
+    duration: form.duration.value,
+    name: form.name.value
+  };
+  if (!booking.time) {
+    alert('Choisissez un créneau.');
+    return;
+  }
+  if (!isAvailable(booking.date, booking.time, parseInt(booking.duration, 10), booking.sport)) {
+    alert('Créneau indisponible');
+    return;
+  }
+  bookings.push(booking);
+  save();
+  form.reset();
+  renderAll();
+});
+
+['date', 'duration', 'sport'].forEach(id => {
+  form[id].addEventListener('change', renderSchedule);
+});
+
+form.date.value = new Date().toISOString().split('T')[0];
+renderAll();

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <h1>Les Acacias</h1>
     <nav>
       <a href="#form">Réserver</a>
+      <a href="admin.html">Admin</a>
     </nav>
   </header>
 
@@ -32,12 +33,9 @@
       <label>Date
         <input type="date" id="date" required />
       </label>
-      <label>Heure
-        <input type="time" id="time" required />
-      </label>
+      <input type="hidden" id="time" required />
       <label>Durée (minutes)
         <select id="duration">
-          <option value="60">60</option>
           <option value="90">90</option>
           <option value="120">120</option>
         </select>
@@ -47,6 +45,7 @@
       </label>
       <button type="submit">Ajouter</button>
     </form>
+    <div id="schedule" class="schedule"></div>
   </section>
 
   <section id="reservations">

--- a/style.css
+++ b/style.css
@@ -11,3 +11,11 @@ button{padding:.5rem 1rem;background:#1976d2;color:#fff;border:0;border-radius:4
 #reservations ul{list-style:none;padding:0;}
 #reservations li{background:#fff;margin-bottom:.5rem;padding:.5rem;border-radius:4px;box-shadow:0 1px 3px rgba(0,0,0,.1);display:flex;justify-content:space-between;align-items:center;}
 #reservations li button{background:#b71c1c;}
+
+.schedule{display:grid;grid-template-columns:repeat(auto-fill,minmax(120px,1fr));gap:.5rem;margin-top:1rem;}
+.schedule .slot{background:#fff;padding:.5rem;border:1px solid #ccc;border-radius:4px;cursor:pointer;}
+.schedule .slot.booked{background:#ddd;cursor:not-allowed;}
+.schedule .slot.selected{border:2px solid #1976d2;}
+.admin-schedule .slot{min-height:3rem;}
+.admin-schedule .slot.booked{background:#f0f0f0;}
+.booking{background:#1976d2;color:#fff;padding:.25rem;border-radius:4px;}


### PR DESCRIPTION
## Summary
- display available 90/120-minute slots and enforce booking conflicts
- add admin planning page with drag-and-drop rescheduling
- style schedule grid for users and admins

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ad86ff21fc83219adf6ca3a7488730